### PR TITLE
Add input validation to greet_user

### DIFF
--- a/hello.py
+++ b/hello.py
@@ -1,6 +1,13 @@
 def greet_user() -> None:
-    """Prompt for a user's name and greet them."""
-    name: str = input("What is your name? ")
+    """Prompt for a user's name and greet them.
+
+    Continues prompting until a non-empty name is provided.
+    """
+    while True:
+        name: str = input("What is your name? ").strip()
+        if name:
+            break
+        print("Please enter a valid name.")
     print(f"Hello, {name}!")
 
 

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -26,3 +26,14 @@ def test_greet_user(monkeypatch, capsys):
     greet_user()
     captured = capsys.readouterr()
     assert captured.out.strip() == 'Hello, Alice!'
+
+
+def test_greet_user_empty_then_valid(monkeypatch, capsys):
+    """Ensure greet_user reprompts when given an empty name."""
+    responses = iter(['', 'Bob'])
+    monkeypatch.setattr('builtins.input', lambda _='': next(responses))
+    greet_user()
+    captured = capsys.readouterr()
+    output_lines = [line.strip() for line in captured.out.splitlines() if line.strip()]
+    assert output_lines[-1] == 'Hello, Bob!'
+    assert 'Please enter a valid name.' in output_lines


### PR DESCRIPTION
## Summary
- prompt repeatedly until the user enters a non-empty name
- expand tests to cover empty name scenario

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b4ba501d083208ead28a22dd72a78