### PR TITLE
Add config-based greeting prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,17 @@ To execute the `hello.py` script, run the following command from the project roo
 python hello.py
 ```
 
-The program will prompt for your name and greet you.
+The program will prompt for your name and greet you. By default it uses the
+prefix `"Hello"` but you can customise this by creating a `config.json` file in
+the working directory containing a `greeting_prefix` entry. For example:
+
+```json
+{
+  "greeting_prefix": "Welcome"
+}
+```
+
+With this configuration, running `hello.py` will greet you with "Welcome".
 
 ## Testing
 

--- a/hello.py
+++ b/hello.py
@@ -1,13 +1,35 @@
+import json
 import logging
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
 
-def greet_user() -> None:
+def load_config(config_path: Path | str = "config.json") -> dict:
+    """Load configuration from *config_path*.
+
+    If the file does not exist or contains invalid JSON, an empty
+    configuration is returned.
+    """
+    path = Path(config_path)
+    try:
+        return json.loads(path.read_text())
+    except FileNotFoundError:
+        logger.info("Config file %s not found, using defaults", path)
+    except json.JSONDecodeError:
+        logger.warning("Config file %s is invalid JSON, using defaults", path)
+    return {}
+
+
+def greet_user(prefix: str | None = None, config_path: Path | str = "config.json") -> None:
     """Prompt for a user's name and greet them.
 
     Continues prompting until a non-empty name is provided.
     """
+    if prefix is None:
+        config = load_config(config_path)
+        prefix = config.get("greeting_prefix", "Hello")
+
     while True:
         name: str = input("What is your name? ").strip()
         if name:
@@ -15,7 +37,7 @@ def greet_user() -> None:
             break
         logger.warning("User entered an empty name")
         print("Please enter a valid name.")
-    print(f"Hello, {name}!")
+    print(f"{prefix}, {name}!")
 
 
 if __name__ == "__main__":

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -51,3 +51,29 @@ def test_hello_script_empty_then_valid(tmp_path):
     output_lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
     assert output_lines[-1].endswith('Hello, Bob!')
     assert 'Please enter a valid name.' in result.stdout
+
+
+def test_greet_user_custom_prefix_from_config(monkeypatch, capsys, tmp_path):
+    """greet_user should read prefix from config.json when provided."""
+    (tmp_path / 'config.json').write_text('{"greeting_prefix": "Welcome"}')
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr('builtins.input', lambda _='': 'Charlie')
+    greet_user()
+    captured = capsys.readouterr()
+    assert captured.out.strip() == 'Welcome, Charlie!'
+
+
+def test_hello_script_uses_config(tmp_path):
+    """Ensure hello.py uses greeting prefix from config.json."""
+    cfg = tmp_path / 'config.json'
+    cfg.write_text('{"greeting_prefix": "Hi"}')
+    script = Path(__file__).resolve().parents[1] / 'hello.py'
+    result = subprocess.run(
+        [sys.executable, str(script)],
+        input='Dana\n',
+        text=True,
+        capture_output=True,
+        check=True,
+        cwd=tmp_path,
+    )
+    assert result.stdout.strip().endswith('Hi, Dana!')


### PR DESCRIPTION
## Summary
- support reading greeting prefix from a `config.json` file
- document new configuration in README
- test configuration support for `greet_user` and `hello.py`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851b9b3f4a08320a22f4fae3dd2adba