### PR TITLE
Add GitHub Actions workflow to run pytest on main changes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,23 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Run tests
+        run: pytest


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that installs dependencies and runs pytest
- trigger the workflow on pushes and pull requests targeting the main branch

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e6abef8e2c832095b027a28e202375