### PR TITLE
Add Dockerfile for LearnCodex Python app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . ./
+
+CMD ["python", "hello.py"]


### PR DESCRIPTION
## Summary
- add a Python 3.12 slim Dockerfile for LearnCodex
- copy the project into /app and install requirements
- configure the container to run hello.py by default

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7f68b33508320b51da3e1d804b3a2