### PR TITLE
Add docker-compose and env-based greeting override

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.9'
+
+services:
+  learncodex:
+    build: .
+    command: ["python", "hello.py"]
+    environment:
+      - GREETING_PREFIX=${GREETING_PREFIX:-Hello}
+    stdin_open: true
+    tty: true

--- a/hello.py
+++ b/hello.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import logging
+import os
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -32,6 +33,9 @@ def greet_user(
     Continues prompting until a non-empty name is provided unless *name* is
     supplied.
     """
+
+    if prefix is None:
+        prefix = os.getenv("GREETING_PREFIX")
 
     if prefix is None:
         config = load_config(config_path)

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -106,6 +106,19 @@ def test_cli_overrides_config_prefix(tmp_path):
     assert output_lines[-1] == 'Salutations, Frank!'
 
 
+def test_env_overrides_config_prefix(monkeypatch, tmp_path):
+    """Environment variables should override config values when present."""
+
+    (tmp_path / 'config.json').write_text('{"greeting_prefix": "Config"}')
+    monkeypatch.setenv('GREETING_PREFIX', 'EnvGreeting')
+
+    result = run_hello_script('Grace\n', cwd=tmp_path)
+    output_lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+    assert output_lines[-1].endswith('EnvGreeting, Grace!')
+    assert 'Config, Grace!' not in result.stdout
+
+
 def test_main_passes_cli_arguments(monkeypatch):
     """Ensure hello.main forwards CLI args to greet_user."""
 


### PR DESCRIPTION
## Summary
- add docker-compose configuration to build and run the application with configurable greeting
- allow greeting prefix to be provided via the GREETING_PREFIX environment variable
- cover environment override behavior with tests

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933747d4978832097bf0710b203a15c)